### PR TITLE
Remove unneeded conduit-combinators

### DIFF
--- a/crypton-conduit.cabal
+++ b/crypton-conduit.cabal
@@ -43,7 +43,6 @@ test-suite crypton-conduit-test
   build-depends:       base
                      , bytestring
                      , conduit
-                     , conduit-combinators
                      , crypton
                      , crypton-conduit
                      , memory


### PR DESCRIPTION
`conduit-combinators` has been merged into `conduit` and deprecated. I have tried to build crypton-conduit with `conduit-combinators` removed and with latest `conduit` without a problem.